### PR TITLE
Add Voronoi Shapes generator application

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -21,6 +21,8 @@
     url: "/applications/cardboard-slicer/"
   - title: "Lead Scanner"
     url: "/applications/lead-scanner/"
+  - title: "Voronoi Shapes"
+    url: "/applications/voronoi-shapes/"
 
 - title: "Search"
   url: "/search/"

--- a/applications/voronoi-shapes/app.css
+++ b/applications/voronoi-shapes/app.css
@@ -1,0 +1,28 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-slate-50 text-slate-900;
+  }
+}
+
+input[type="range"] {
+  @apply accent-violet-600;
+}
+
+input[type="color"] {
+  @apply w-8 h-8 rounded cursor-pointer border border-slate-300;
+  padding: 1px;
+}
+
+.canvas-container {
+  cursor: crosshair;
+}
+
+.canvas-container canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}

--- a/applications/voronoi-shapes/main.jsx
+++ b/applications/voronoi-shapes/main.jsx
@@ -28,6 +28,8 @@ const DEFAULT_SETTINGS = {
   gradientStart: '#FF6B6B',
   gradientEnd: '#4ECDC4',
   fillTolerance: 30,
+  gapWidth: 4,
+  smoothIterations: 2,
 };
 
 const REGION_COLORS = [
@@ -84,6 +86,84 @@ function floodFill(imageData, startX, startY, tolerance) {
   }
 
   return { mask, bounds: { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY + 1 } };
+}
+
+function erodeMask(mask, width, height, radius) {
+  if (radius <= 0) return mask;
+  const r = Math.ceil(radius);
+
+  // Horizontal pass: pixel survives only if all pixels in row within ±r are set
+  const hPass = new Uint8Array(width * height);
+  for (let y = 0; y < height; y++) {
+    const row = y * width;
+    for (let x = r; x < width - r; x++) {
+      let ok = true;
+      for (let dx = -r; dx <= r; dx++) {
+        if (!mask[row + x + dx]) { ok = false; break; }
+      }
+      if (ok) hPass[row + x] = 1;
+    }
+  }
+
+  // Vertical pass on horizontal result
+  const result = new Uint8Array(width * height);
+  for (let x = 0; x < width; x++) {
+    for (let y = r; y < height - r; y++) {
+      let ok = true;
+      for (let dy = -r; dy <= r; dy++) {
+        if (!hPass[(y + dy) * width + x]) { ok = false; break; }
+      }
+      if (ok) result[y * width + x] = 1;
+    }
+  }
+  return result;
+}
+
+function computeBounds(mask, width, height) {
+  let minX = width, maxX = 0, minY = height, maxY = 0;
+  let count = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (mask[y * width + x]) {
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+        count++;
+      }
+    }
+  }
+  if (count === 0) return null;
+  return { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY + 1 };
+}
+
+function sampleBoundaryGuards(erodedMask, width, height, spacing) {
+  // Find pixels just OUTSIDE the eroded mask that are adjacent to it.
+  // These form a dense ring of guard Voronoi sites that push interior
+  // cells inward, creating organic curved edges along boundaries.
+  const guards = [];
+  const cellSize = Math.max(2, Math.round(spacing));
+  const seen = new Set();
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (erodedMask[y * width + x]) continue; // skip interior pixels
+      // Is this pixel adjacent to the eroded mask?
+      const adj =
+        (x > 0 && erodedMask[y * width + x - 1]) ||
+        (x < width - 1 && erodedMask[y * width + x + 1]) ||
+        (y > 0 && erodedMask[(y - 1) * width + x]) ||
+        (y < height - 1 && erodedMask[(y + 1) * width + x]);
+      if (!adj) continue;
+
+      // Spatial subsampling — one guard per cellSize x cellSize grid cell
+      const key = `${Math.floor(x / cellSize)},${Math.floor(y / cellSize)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      guards.push([x, y]);
+    }
+  }
+  return guards;
 }
 
 function bestCandidateSampling(mask, bounds, canvasWidth, count) {
@@ -153,6 +233,89 @@ function thickenStrokes(svgContent) {
     .replace(/stroke-width\s*=\s*"[\d.]+[a-z]*"/gi, 'stroke-width="2"');
 }
 
+function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
+  const d = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+  if (Math.abs(d) < 1e-10) return null;
+  const t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / d;
+  return [x1 + t * (x2 - x1), y1 + t * (y2 - y1)];
+}
+
+function insetPolygon(polygon, amount) {
+  if (amount <= 0) return polygon;
+  const n = polygon.length - 1; // d3 voronoi closes polygons (last === first)
+  if (n < 3) return null;
+
+  // Centroid for determining inward direction
+  let cx = 0, cy = 0;
+  for (let i = 0; i < n; i++) { cx += polygon[i][0]; cy += polygon[i][1]; }
+  cx /= n; cy /= n;
+
+  // Offset each edge inward
+  const edges = [];
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const dx = polygon[j][0] - polygon[i][0];
+    const dy = polygon[j][1] - polygon[i][1];
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len < 1e-10) continue;
+
+    // Normal perpendicular to edge
+    let nx = -dy / len, ny = dx / len;
+
+    // Ensure it points inward (toward centroid)
+    const mx = (polygon[i][0] + polygon[j][0]) / 2;
+    const my = (polygon[i][1] + polygon[j][1]) / 2;
+    if (nx * (cx - mx) + ny * (cy - my) < 0) { nx = -nx; ny = -ny; }
+
+    edges.push({
+      x1: polygon[i][0] + nx * amount, y1: polygon[i][1] + ny * amount,
+      x2: polygon[j][0] + nx * amount, y2: polygon[j][1] + ny * amount,
+    });
+  }
+
+  if (edges.length < 3) return null;
+
+  // Intersect adjacent offset edges to form the inset polygon
+  const result = [];
+  for (let i = 0; i < edges.length; i++) {
+    const j = (i + 1) % edges.length;
+    const pt = lineIntersection(
+      edges[i].x1, edges[i].y1, edges[i].x2, edges[i].y2,
+      edges[j].x1, edges[j].y1, edges[j].x2, edges[j].y2,
+    );
+    if (pt) result.push(pt);
+  }
+
+  if (result.length < 3) return null; // collapsed to nothing
+  result.push(result[0]); // close the polygon
+  return result;
+}
+
+function chaikinSmooth(polygon, iterations) {
+  if (iterations <= 0) return polygon;
+  let pts = polygon.slice(0, -1); // remove closing point
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const next = [];
+    const n = pts.length;
+    for (let i = 0; i < n; i++) {
+      const j = (i + 1) % n;
+      next.push([
+        0.75 * pts[i][0] + 0.25 * pts[j][0],
+        0.75 * pts[i][1] + 0.25 * pts[j][1],
+      ]);
+      next.push([
+        0.25 * pts[i][0] + 0.75 * pts[j][0],
+        0.25 * pts[i][1] + 0.75 * pts[j][1],
+      ]);
+    }
+    pts = next;
+  }
+
+  pts.push(pts[0]); // re-close
+  return pts;
+}
+
 function parseSVGDimensions(svgContent) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(svgContent, 'image/svg+xml');
@@ -217,23 +380,46 @@ function maskToSVGPath(mask, width, height, blockSize = 2) {
 }
 
 function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight) {
-  const points = bestCandidateSampling(region.mask, region.bounds, canvasWidth, settings.pointCount);
-  if (points.length < 2) return [];
+  const erosionRadius = Math.ceil(settings.gapWidth / 2);
+  const erodedMask = erodeMask(region.mask, canvasWidth, canvasHeight, erosionRadius);
+  const erodedBounds = computeBounds(erodedMask, canvasWidth, canvasHeight);
+  if (!erodedBounds) return { cells: [], erodedMask };
 
-  const delaunay = Delaunay.from(points);
+  // Interior points — these become rendered cells
+  const interiorPoints = bestCandidateSampling(erodedMask, erodedBounds, canvasWidth, settings.pointCount);
+  if (interiorPoints.length < 2) return { cells: [], erodedMask };
+
+  // Dense guard points tracing the eroded mask boundary — push interior
+  // cells inward so they curve organically near edges instead of being
+  // hard-clipped. Spacing ~1/4 of average inter-cell distance ensures
+  // smooth curves even along rounded corners.
+  const area = erodedBounds.w * erodedBounds.h;
+  const avgSpacing = Math.sqrt(area / settings.pointCount);
+  const guardSpacing = Math.max(3, Math.floor(avgSpacing / 4));
+  const guardPoints = sampleBoundaryGuards(erodedMask, canvasWidth, canvasHeight, guardSpacing);
+
+  const allPoints = [...interiorPoints, ...guardPoints];
+  const delaunay = Delaunay.from(allPoints);
   const voronoi = delaunay.voronoi([0, 0, canvasWidth, canvasHeight]);
   const cells = [];
+  const insetAmount = settings.gapWidth / 2; // half gap per side
 
-  for (let i = 0; i < points.length; i++) {
+  // Only generate cells for interior points (not guards)
+  for (let i = 0; i < interiorPoints.length; i++) {
     const poly = voronoi.cellPolygon(i);
-    if (poly) {
-      cells.push({
-        polygon: poly,
-        color: generateCellColor(i, points.length, settings),
-      });
-    }
+    if (!poly) continue;
+
+    // Inset for laser-cut gaps, then smooth for organic look
+    const inset = insetPolygon(poly, insetAmount);
+    if (!inset) continue; // cell collapsed, skip
+
+    const smoothed = chaikinSmooth(inset, settings.smoothIterations);
+    cells.push({
+      polygon: smoothed,
+      color: generateCellColor(i, interiorPoints.length, settings),
+    });
   }
-  return cells;
+  return { cells, erodedMask };
 }
 
 function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voronoiMap, settings) {
@@ -243,16 +429,18 @@ function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voron
   ctx.drawImage(svgImage, 0, 0, canvasWidth, canvasHeight);
 
   for (const region of regions) {
-    const cells = voronoiMap.get(region.id);
+    const data = voronoiMap.get(region.id);
+    const cells = data?.cells;
+    const clipMask = data?.erodedMask || region.mask;
 
-    // Create mask canvas
+    // Create mask canvas using eroded mask for cell clipping
     const maskCvs = document.createElement('canvas');
     maskCvs.width = canvasWidth;
     maskCvs.height = canvasHeight;
     const maskCtx = maskCvs.getContext('2d');
     const maskImg = maskCtx.createImageData(canvasWidth, canvasHeight);
-    for (let i = 0; i < region.mask.length; i++) {
-      if (region.mask[i]) {
+    for (let i = 0; i < clipMask.length; i++) {
+      if (clipMask[i]) {
         const o = i * 4;
         maskImg.data[o] = 255;
         maskImg.data[o + 1] = 255;
@@ -324,11 +512,13 @@ function exportAsSVG(svgContent, canvasWidth, canvasHeight, regions, voronoiMap,
   const regionGroups = [];
 
   regions.forEach((region, idx) => {
-    const cells = voronoiMap.get(region.id);
+    const data = voronoiMap.get(region.id);
+    const cells = data?.cells;
     if (!cells || cells.length === 0) return;
 
+    const clipMask = data?.erodedMask || region.mask;
     const clipId = `region-clip-${idx}`;
-    const pathD = maskToSVGPath(region.mask, canvasWidth, canvasHeight);
+    const pathD = maskToSVGPath(clipMask, canvasWidth, canvasHeight);
     regionDefs.push(`<clipPath id="${clipId}"><path d="${pathD}"/></clipPath>`);
 
     const polys = cells.map(cell => {
@@ -436,8 +626,8 @@ const App = () => {
     }
     const map = new Map();
     for (const region of regions) {
-      const cells = generateVoronoiForRegion(region, settings, canvasSize.width, canvasSize.height);
-      map.set(region.id, cells);
+      const data = generateVoronoiForRegion(region, settings, canvasSize.width, canvasSize.height);
+      map.set(region.id, data);
     }
     setVoronoiMap(map);
   }, [regions, settings, canvasSize, regenKey]);
@@ -691,6 +881,24 @@ const App = () => {
                     <input type="range" min="5" max="500" value={settings.pointCount}
                       onChange={(e) => updateSetting('pointCount', parseInt(e.target.value))}
                       className="w-full mt-1" />
+                  </label>
+
+                  {/* Gap Width (web thickness for laser cutting) */}
+                  <label className="block">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Gap Width: {settings.gapWidth}px</span>
+                    <input type="range" min="0" max="20" step="0.5" value={settings.gapWidth}
+                      onChange={(e) => updateSetting('gapWidth', parseFloat(e.target.value))}
+                      className="w-full mt-1" />
+                    <span className="text-[10px] text-slate-400">Width of the web between cells. Each cell is a separate island for laser cutting.</span>
+                  </label>
+
+                  {/* Smoothing */}
+                  <label className="block">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Smoothing: {settings.smoothIterations}</span>
+                    <input type="range" min="0" max="4" value={settings.smoothIterations}
+                      onChange={(e) => updateSetting('smoothIterations', parseInt(e.target.value))}
+                      className="w-full mt-1" />
+                    <span className="text-[10px] text-slate-400">0 = angular Voronoi edges, higher = more organic curves.</span>
                   </label>
 
                   {/* Color Mode */}

--- a/applications/voronoi-shapes/main.jsx
+++ b/applications/voronoi-shapes/main.jsx
@@ -1,0 +1,804 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+import {
+  Upload, Download, Trash2, RotateCcw, Save, FileUp, FileDown,
+  MousePointer2, Settings2, ChevronDown, ChevronUp, Hexagon
+} from 'lucide-react';
+import { Delaunay } from 'd3-delaunay';
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import './app.css';
+
+function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}
+
+// --- Constants ---
+
+const STORAGE_KEY = 'voronoi-shapes-settings';
+const MAX_CANVAS_SIZE = 900;
+
+const DEFAULT_SETTINGS = {
+  pointCount: 100,
+  colorMode: 'random',
+  colorPalette: ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD', '#98D8C8'],
+  strokeWidth: 1,
+  strokeColor: '#333333',
+  cellOpacity: 0.85,
+  gradientStart: '#FF6B6B',
+  gradientEnd: '#4ECDC4',
+  fillTolerance: 30,
+};
+
+const REGION_COLORS = [
+  [255, 107, 107],
+  [78, 205, 196],
+  [69, 183, 209],
+  [150, 206, 180],
+  [255, 234, 167],
+  [221, 160, 221],
+];
+
+// --- Algorithms ---
+
+function floodFill(imageData, startX, startY, tolerance) {
+  const { width, height, data } = imageData;
+  const mask = new Uint8Array(width * height);
+  const idx = (x, y) => (y * width + x) * 4;
+
+  const si = idx(startX, startY);
+  const sr = data[si], sg = data[si + 1], sb = data[si + 2], sa = data[si + 3];
+
+  const matches = (x, y) => {
+    const i = idx(x, y);
+    return Math.abs(data[i] - sr) <= tolerance &&
+      Math.abs(data[i + 1] - sg) <= tolerance &&
+      Math.abs(data[i + 2] - sb) <= tolerance &&
+      Math.abs(data[i + 3] - sa) <= tolerance;
+  };
+
+  const stack = [startX, startY];
+  mask[startY * width + startX] = 1;
+  let minX = startX, maxX = startX, minY = startY, maxY = startY;
+
+  while (stack.length > 0) {
+    const y = stack.pop();
+    const x = stack.pop();
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+
+    if (x + 1 < width && !mask[y * width + x + 1] && matches(x + 1, y)) {
+      mask[y * width + x + 1] = 1; stack.push(x + 1, y);
+    }
+    if (x - 1 >= 0 && !mask[y * width + x - 1] && matches(x - 1, y)) {
+      mask[y * width + x - 1] = 1; stack.push(x - 1, y);
+    }
+    if (y + 1 < height && !mask[(y + 1) * width + x] && matches(x, y + 1)) {
+      mask[(y + 1) * width + x] = 1; stack.push(x, y + 1);
+    }
+    if (y - 1 >= 0 && !mask[(y - 1) * width + x] && matches(x, y - 1)) {
+      mask[(y - 1) * width + x] = 1; stack.push(x, y - 1);
+    }
+  }
+
+  return { mask, bounds: { x: minX, y: minY, w: maxX - minX + 1, h: maxY - minY + 1 } };
+}
+
+function bestCandidateSampling(mask, bounds, canvasWidth, count) {
+  const points = [];
+  const candidatesPerPoint = 20;
+  const maxAttempts = count * 100;
+  let attempts = 0;
+
+  while (points.length < count && attempts < maxAttempts) {
+    let bestDist = -1;
+    let bestX = 0, bestY = 0;
+
+    const numCandidates = points.length === 0 ? 1 : candidatesPerPoint;
+    for (let c = 0; c < numCandidates; c++) {
+      const cx = bounds.x + Math.random() * bounds.w;
+      const cy = bounds.y + Math.random() * bounds.h;
+      const px = Math.floor(cx);
+      const py = Math.floor(cy);
+
+      if (px < 0 || py < 0 || px >= canvasWidth || !mask[py * canvasWidth + px]) {
+        attempts++;
+        continue;
+      }
+
+      let minDist = Infinity;
+      for (const [ex, ey] of points) {
+        const d = (cx - ex) * (cx - ex) + (cy - ey) * (cy - ey);
+        if (d < minDist) minDist = d;
+      }
+
+      if (minDist > bestDist) {
+        bestDist = minDist;
+        bestX = cx;
+        bestY = cy;
+      }
+      attempts++;
+    }
+
+    if (bestDist >= 0) {
+      points.push([bestX, bestY]);
+    }
+  }
+  return points;
+}
+
+function interpolateColor(c1, c2, t) {
+  const r1 = parseInt(c1.slice(1, 3), 16), g1 = parseInt(c1.slice(3, 5), 16), b1 = parseInt(c1.slice(5, 7), 16);
+  const r2 = parseInt(c2.slice(1, 3), 16), g2 = parseInt(c2.slice(3, 5), 16), b2 = parseInt(c2.slice(5, 7), 16);
+  const r = Math.round(r1 + (r2 - r1) * t), g = Math.round(g1 + (g2 - g1) * t), b = Math.round(b1 + (b2 - b1) * t);
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
+function generateCellColor(index, total, settings) {
+  const { colorMode, colorPalette, gradientStart, gradientEnd } = settings;
+  if (colorMode === 'gradient') {
+    return interpolateColor(gradientStart, gradientEnd, total > 1 ? index / (total - 1) : 0);
+  }
+  if (colorMode === 'palette') {
+    return colorPalette[index % colorPalette.length];
+  }
+  return colorPalette[Math.floor(Math.random() * colorPalette.length)];
+}
+
+function thickenStrokes(svgContent) {
+  return svgContent
+    .replace(/stroke-width\s*:\s*[\d.]+\s*[a-z]*/gi, 'stroke-width:2')
+    .replace(/stroke-width\s*=\s*"[\d.]+[a-z]*"/gi, 'stroke-width="2"');
+}
+
+function parseSVGDimensions(svgContent) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgContent, 'image/svg+xml');
+  const svg = doc.querySelector('svg');
+  const vb = svg.getAttribute('viewBox');
+  if (vb) {
+    const parts = vb.trim().split(/[\s,]+/).map(Number);
+    return { width: parts[2], height: parts[3] };
+  }
+  return { width: parseFloat(svg.getAttribute('width')) || 800, height: parseFloat(svg.getAttribute('height')) || 600 };
+}
+
+function maskToSVGPath(mask, width, height, blockSize = 2) {
+  const bw = Math.ceil(width / blockSize);
+  const bh = Math.ceil(height / blockSize);
+
+  const spans = [];
+  for (let by = 0; by < bh; by++) {
+    let bx = 0;
+    while (bx < bw) {
+      let count = 0, total = 0;
+      for (let dy = 0; dy < blockSize && by * blockSize + dy < height; dy++) {
+        for (let dx = 0; dx < blockSize && bx * blockSize + dx < width; dx++) {
+          total++;
+          if (mask[(by * blockSize + dy) * width + (bx * blockSize + dx)]) count++;
+        }
+      }
+      if (count > total / 2) {
+        const startBx = bx;
+        bx++;
+        while (bx < bw) {
+          let c2 = 0, t2 = 0;
+          for (let dy = 0; dy < blockSize && by * blockSize + dy < height; dy++) {
+            for (let dx = 0; dx < blockSize && bx * blockSize + dx < width; dx++) {
+              t2++;
+              if (mask[(by * blockSize + dy) * width + (bx * blockSize + dx)]) c2++;
+            }
+          }
+          if (c2 <= t2 / 2) break;
+          bx++;
+        }
+        spans.push({ x: startBx * blockSize, y: by * blockSize, w: (bx - startBx) * blockSize, h: blockSize });
+      } else {
+        bx++;
+      }
+    }
+  }
+
+  // Merge vertically
+  for (let i = 0; i < spans.length; i++) {
+    if (!spans[i]) continue;
+    for (let j = i + 1; j < spans.length; j++) {
+      if (!spans[j]) continue;
+      if (spans[j].x === spans[i].x && spans[j].w === spans[i].w && spans[j].y === spans[i].y + spans[i].h) {
+        spans[i].h += spans[j].h;
+        spans[j] = null;
+      }
+    }
+  }
+
+  return spans.filter(Boolean).map(s => `M${s.x} ${s.y}h${s.w}v${s.h}h${-s.w}Z`).join('');
+}
+
+function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight) {
+  const points = bestCandidateSampling(region.mask, region.bounds, canvasWidth, settings.pointCount);
+  if (points.length < 2) return [];
+
+  const delaunay = Delaunay.from(points);
+  const voronoi = delaunay.voronoi([0, 0, canvasWidth, canvasHeight]);
+  const cells = [];
+
+  for (let i = 0; i < points.length; i++) {
+    const poly = voronoi.cellPolygon(i);
+    if (poly) {
+      cells.push({
+        polygon: poly,
+        color: generateCellColor(i, points.length, settings),
+      });
+    }
+  }
+  return cells;
+}
+
+function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voronoiMap, settings) {
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+  ctx.drawImage(svgImage, 0, 0, canvasWidth, canvasHeight);
+
+  for (const region of regions) {
+    const cells = voronoiMap.get(region.id);
+
+    // Create mask canvas
+    const maskCvs = document.createElement('canvas');
+    maskCvs.width = canvasWidth;
+    maskCvs.height = canvasHeight;
+    const maskCtx = maskCvs.getContext('2d');
+    const maskImg = maskCtx.createImageData(canvasWidth, canvasHeight);
+    for (let i = 0; i < region.mask.length; i++) {
+      if (region.mask[i]) {
+        const o = i * 4;
+        maskImg.data[o] = 255;
+        maskImg.data[o + 1] = 255;
+        maskImg.data[o + 2] = 255;
+        maskImg.data[o + 3] = 255;
+      }
+    }
+    maskCtx.putImageData(maskImg, 0, 0);
+
+    if (cells && cells.length > 0) {
+      const cellCvs = document.createElement('canvas');
+      cellCvs.width = canvasWidth;
+      cellCvs.height = canvasHeight;
+      const cellCtx = cellCvs.getContext('2d');
+      cellCtx.globalAlpha = settings.cellOpacity;
+
+      for (const cell of cells) {
+        cellCtx.beginPath();
+        cellCtx.moveTo(cell.polygon[0][0], cell.polygon[0][1]);
+        for (let j = 1; j < cell.polygon.length; j++) {
+          cellCtx.lineTo(cell.polygon[j][0], cell.polygon[j][1]);
+        }
+        cellCtx.closePath();
+        cellCtx.fillStyle = cell.color;
+        cellCtx.fill();
+        if (settings.strokeWidth > 0) {
+          cellCtx.globalAlpha = 1;
+          cellCtx.strokeStyle = settings.strokeColor;
+          cellCtx.lineWidth = settings.strokeWidth;
+          cellCtx.stroke();
+          cellCtx.globalAlpha = settings.cellOpacity;
+        }
+      }
+
+      cellCtx.globalCompositeOperation = 'destination-in';
+      cellCtx.globalAlpha = 1;
+      cellCtx.drawImage(maskCvs, 0, 0);
+
+      ctx.drawImage(cellCvs, 0, 0);
+    } else {
+      // Highlight unprocessed region
+      const [r, g, b] = region.color;
+      const hImg = maskCtx.createImageData(canvasWidth, canvasHeight);
+      for (let i = 0; i < region.mask.length; i++) {
+        if (region.mask[i]) {
+          const o = i * 4;
+          hImg.data[o] = r;
+          hImg.data[o + 1] = g;
+          hImg.data[o + 2] = b;
+          hImg.data[o + 3] = 80;
+        }
+      }
+      const hCvs = document.createElement('canvas');
+      hCvs.width = canvasWidth;
+      hCvs.height = canvasHeight;
+      hCvs.getContext('2d').putImageData(hImg, 0, 0);
+      ctx.drawImage(hCvs, 0, 0);
+    }
+  }
+
+  // Redraw strokes on top using multiply
+  ctx.globalCompositeOperation = 'multiply';
+  ctx.drawImage(svgImage, 0, 0, canvasWidth, canvasHeight);
+  ctx.globalCompositeOperation = 'source-over';
+}
+
+function exportAsSVG(svgContent, canvasWidth, canvasHeight, regions, voronoiMap, settings, svgDims) {
+  const regionDefs = [];
+  const regionGroups = [];
+
+  regions.forEach((region, idx) => {
+    const cells = voronoiMap.get(region.id);
+    if (!cells || cells.length === 0) return;
+
+    const clipId = `region-clip-${idx}`;
+    const pathD = maskToSVGPath(region.mask, canvasWidth, canvasHeight);
+    regionDefs.push(`<clipPath id="${clipId}"><path d="${pathD}"/></clipPath>`);
+
+    const polys = cells.map(cell => {
+      const pts = cell.polygon.map(p => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
+      return `<polygon points="${pts}" fill="${cell.color}" fill-opacity="${settings.cellOpacity}" stroke="${settings.strokeColor}" stroke-width="${settings.strokeWidth}"/>`;
+    }).join('\n      ');
+
+    regionGroups.push(`<g clip-path="url(#${clipId})">\n      ${polys}\n    </g>`);
+  });
+
+  // Re-embed original SVG content as nested SVG for strokes
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgContent, 'image/svg+xml');
+  const origSvg = doc.querySelector('svg');
+  const origContent = origSvg.innerHTML;
+  const origViewBox = origSvg.getAttribute('viewBox') || `0 0 ${svgDims.width} ${svgDims.height}`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${canvasWidth}" height="${canvasHeight}" viewBox="0 0 ${canvasWidth} ${canvasHeight}">
+  <defs>
+    ${regionDefs.join('\n    ')}
+  </defs>
+  <rect width="${canvasWidth}" height="${canvasHeight}" fill="white"/>
+  ${regionGroups.join('\n  ')}
+  <svg x="0" y="0" width="${canvasWidth}" height="${canvasHeight}" viewBox="${origViewBox}">
+    ${origContent}
+  </svg>
+</svg>`;
+}
+
+// --- App Component ---
+
+const App = () => {
+  const [svgContent, setSvgContent] = useState(null);
+  const [svgImage, setSvgImage] = useState(null);
+  const [thickSvgImage, setThickSvgImage] = useState(null);
+  const [svgDims, setSvgDims] = useState(null);
+  const [canvasSize, setCanvasSize] = useState({ width: 800, height: 600 });
+  const [regions, setRegions] = useState([]);
+  const [voronoiMap, setVoronoiMap] = useState(new Map());
+  const [settings, setSettings] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? { ...DEFAULT_SETTINGS, ...JSON.parse(saved) } : DEFAULT_SETTINGS;
+  });
+  const [settingsOpen, setSettingsOpen] = useState(true);
+  const [regenKey, setRegenKey] = useState(0);
+
+  const canvasRef = useRef(null);
+  const thickCanvasRef = useRef(null);
+  const fileInputRef = useRef(null);
+  const settingsInputRef = useRef(null);
+
+  // Persist settings
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  // Load SVG into images
+  useEffect(() => {
+    if (!svgContent) return;
+    const dims = parseSVGDimensions(svgContent);
+    setSvgDims(dims);
+
+    const scale = Math.min(MAX_CANVAS_SIZE / dims.width, MAX_CANVAS_SIZE / dims.height, 5);
+    const cw = Math.round(dims.width * scale);
+    const ch = Math.round(dims.height * scale);
+    setCanvasSize({ width: cw, height: ch });
+
+    // Load original SVG image
+    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => { setSvgImage(img); URL.revokeObjectURL(url); };
+    img.src = url;
+
+    // Load thick-stroke SVG for flood fill
+    const thickSvg = thickenStrokes(svgContent);
+    const tBlob = new Blob([thickSvg], { type: 'image/svg+xml' });
+    const tUrl = URL.createObjectURL(tBlob);
+    const tImg = new Image();
+    tImg.onload = () => { setThickSvgImage(tImg); URL.revokeObjectURL(tUrl); };
+    tImg.src = tUrl;
+
+    setRegions([]);
+    setVoronoiMap(new Map());
+  }, [svgContent]);
+
+  // Render thick SVG to offscreen canvas
+  useEffect(() => {
+    if (!thickSvgImage || !thickCanvasRef.current) return;
+    const cvs = thickCanvasRef.current;
+    cvs.width = canvasSize.width;
+    cvs.height = canvasSize.height;
+    const ctx = cvs.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvasSize.width, canvasSize.height);
+    ctx.drawImage(thickSvgImage, 0, 0, canvasSize.width, canvasSize.height);
+  }, [thickSvgImage, canvasSize]);
+
+  // Generate Voronoi for all regions
+  useEffect(() => {
+    if (regions.length === 0) {
+      setVoronoiMap(new Map());
+      return;
+    }
+    const map = new Map();
+    for (const region of regions) {
+      const cells = generateVoronoiForRegion(region, settings, canvasSize.width, canvasSize.height);
+      map.set(region.id, cells);
+    }
+    setVoronoiMap(map);
+  }, [regions, settings, canvasSize, regenKey]);
+
+  // Render canvas
+  useEffect(() => {
+    if (!svgImage || !canvasRef.current) return;
+    const cvs = canvasRef.current;
+    cvs.width = canvasSize.width;
+    cvs.height = canvasSize.height;
+    const ctx = cvs.getContext('2d');
+    renderToCanvas(ctx, canvasSize.width, canvasSize.height, svgImage, regions, voronoiMap, settings);
+  }, [svgImage, regions, voronoiMap, settings, canvasSize]);
+
+  const handleFileUpload = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setSvgContent(ev.target.result);
+    reader.readAsText(file);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.name.endsWith('.svg')) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setSvgContent(ev.target.result);
+    reader.readAsText(file);
+  };
+
+  const handleCanvasClick = (e) => {
+    if (!thickCanvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const scaleX = canvasSize.width / rect.width;
+    const scaleY = canvasSize.height / rect.height;
+    const x = Math.floor((e.clientX - rect.left) * scaleX);
+    const y = Math.floor((e.clientY - rect.top) * scaleY);
+
+    // Check if clicking existing region to deselect
+    for (const region of regions) {
+      if (region.mask[y * canvasSize.width + x]) {
+        setRegions(prev => prev.filter(r => r.id !== region.id));
+        return;
+      }
+    }
+
+    // Flood fill on thick-stroke canvas
+    const ctx = thickCanvasRef.current.getContext('2d');
+    const imageData = ctx.getImageData(0, 0, canvasSize.width, canvasSize.height);
+    const { mask, bounds } = floodFill(imageData, x, y, settings.fillTolerance);
+
+    const pixelCount = mask.reduce((s, v) => s + v, 0);
+    if (pixelCount < 50) return;
+
+    setRegions(prev => [...prev, {
+      id: Date.now(),
+      mask,
+      bounds,
+      color: REGION_COLORS[prev.length % REGION_COLORS.length],
+    }]);
+  };
+
+  const handleExportSVG = () => {
+    if (!svgContent || regions.length === 0) return;
+    const svg = exportAsSVG(svgContent, canvasSize.width, canvasSize.height, regions, voronoiMap, settings, svgDims);
+    const blob = new Blob([svg], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `voronoi-${Date.now()}.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportSettings = () => {
+    const blob = new Blob([JSON.stringify(settings, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'voronoi-settings.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportSettings = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const imported = JSON.parse(ev.target.result);
+        setSettings({ ...DEFAULT_SETTINGS, ...imported });
+      } catch { /* ignore invalid JSON */ }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  const updateSetting = (key, value) => {
+    setSettings(prev => ({ ...prev, [key]: value }));
+  };
+
+  const updatePaletteColor = (index, color) => {
+    setSettings(prev => {
+      const palette = [...prev.colorPalette];
+      palette[index] = color;
+      return { ...prev, colorPalette: palette };
+    });
+  };
+
+  const addPaletteColor = () => {
+    setSettings(prev => ({
+      ...prev,
+      colorPalette: [...prev.colorPalette, '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0')],
+    }));
+  };
+
+  const removePaletteColor = (index) => {
+    if (settings.colorPalette.length <= 1) return;
+    setSettings(prev => ({
+      ...prev,
+      colorPalette: prev.colorPalette.filter((_, i) => i !== index),
+    }));
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-slate-50 font-sans text-slate-900">
+      {/* Header */}
+      <header className="bg-violet-700 h-14 flex items-center justify-between px-5 shadow-md shrink-0">
+        <div className="flex items-center gap-2">
+          <Hexagon className="text-white" size={22} />
+          <h1 className="text-white text-lg font-bold">Voronoi Shapes</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <button onClick={handleExportSettings} title="Export settings" className="p-2 text-violet-200 hover:text-white transition-colors">
+            <FileDown size={18} />
+          </button>
+          <button onClick={() => settingsInputRef.current?.click()} title="Import settings" className="p-2 text-violet-200 hover:text-white transition-colors">
+            <FileUp size={18} />
+          </button>
+          <input ref={settingsInputRef} type="file" accept=".json" className="hidden" onChange={handleImportSettings} />
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-auto">
+        {!svgContent ? (
+          /* Upload Area */
+          <div
+            className="flex flex-col items-center justify-center p-12 m-6 border-4 border-dashed border-slate-300 rounded-3xl bg-white min-h-[400px] cursor-pointer hover:border-violet-400 hover:bg-violet-50/30 transition-all"
+            onClick={() => fileInputRef.current?.click()}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={handleDrop}
+          >
+            <Upload size={56} className="text-slate-300 mb-6" />
+            <p className="text-xl font-bold text-slate-600 mb-2">Upload SVG File</p>
+            <p className="text-sm text-slate-400">Drag & drop or click to browse</p>
+            <input ref={fileInputRef} type="file" accept=".svg" className="hidden" onChange={handleFileUpload} />
+          </div>
+        ) : (
+          <div className="p-4 space-y-4">
+            {/* Canvas */}
+            <div className="bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
+              <div className="flex items-center justify-between px-4 py-2 bg-slate-50 border-b border-slate-200">
+                <span className="text-xs font-bold text-slate-500 flex items-center gap-2">
+                  <MousePointer2 size={14} />
+                  Click regions to select/deselect
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => { fileInputRef.current?.click(); }}
+                    className="text-xs text-slate-500 hover:text-violet-600 font-bold transition-colors"
+                  >
+                    New SVG
+                  </button>
+                  <input ref={fileInputRef} type="file" accept=".svg" className="hidden" onChange={handleFileUpload} />
+                </div>
+              </div>
+              <div className="canvas-container flex justify-center p-4 bg-slate-100/50">
+                <canvas
+                  ref={canvasRef}
+                  onClick={handleCanvasClick}
+                  style={{ maxWidth: '100%', height: 'auto' }}
+                />
+              </div>
+            </div>
+
+            {/* Selected Regions */}
+            {regions.length > 0 && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Regions:</span>
+                {regions.map((region, idx) => (
+                  <button
+                    key={region.id}
+                    onClick={() => setRegions(prev => prev.filter(r => r.id !== region.id))}
+                    className="flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-200 rounded-full text-xs font-bold text-slate-600 hover:border-red-300 hover:text-red-500 transition-all"
+                  >
+                    <span className="w-3 h-3 rounded-full" style={{ backgroundColor: `rgb(${region.color.join(',')})` }} />
+                    Region {idx + 1}
+                    <span className="text-slate-300 ml-0.5">&times;</span>
+                  </button>
+                ))}
+                <button
+                  onClick={() => setRegions([])}
+                  className="p-1.5 text-slate-400 hover:text-red-500 transition-colors"
+                  title="Clear all"
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-2 flex-wrap">
+              <button
+                onClick={() => setRegenKey(k => k + 1)}
+                disabled={regions.length === 0}
+                className="flex items-center gap-2 px-4 py-2.5 bg-violet-600 hover:bg-violet-700 disabled:opacity-30 text-white rounded-xl text-xs font-bold transition-all shadow-sm"
+              >
+                <RotateCcw size={14} />
+                Regenerate
+              </button>
+              <button
+                onClick={handleExportSVG}
+                disabled={regions.length === 0 || voronoiMap.size === 0}
+                className="flex items-center gap-2 px-4 py-2.5 bg-slate-800 hover:bg-slate-900 disabled:opacity-30 text-white rounded-xl text-xs font-bold transition-all shadow-sm"
+              >
+                <Download size={14} />
+                Download SVG
+              </button>
+            </div>
+
+            {/* Settings Panel */}
+            <div className="bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
+              <button
+                onClick={() => setSettingsOpen(o => !o)}
+                className="w-full flex items-center justify-between px-4 py-3 hover:bg-slate-50 transition-colors"
+              >
+                <span className="flex items-center gap-2 text-sm font-bold text-slate-700">
+                  <Settings2 size={16} />
+                  Settings
+                </span>
+                {settingsOpen ? <ChevronUp size={16} className="text-slate-400" /> : <ChevronDown size={16} className="text-slate-400" />}
+              </button>
+
+              {settingsOpen && (
+                <div className="px-4 pb-4 space-y-4 border-t border-slate-100">
+                  {/* Point Count */}
+                  <label className="block pt-3">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Points: {settings.pointCount}</span>
+                    <input type="range" min="5" max="500" value={settings.pointCount}
+                      onChange={(e) => updateSetting('pointCount', parseInt(e.target.value))}
+                      className="w-full mt-1" />
+                  </label>
+
+                  {/* Color Mode */}
+                  <label className="block">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Color Mode</span>
+                    <select value={settings.colorMode}
+                      onChange={(e) => updateSetting('colorMode', e.target.value)}
+                      className="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm font-medium">
+                      <option value="random">Random from palette</option>
+                      <option value="palette">Sequential from palette</option>
+                      <option value="gradient">Gradient</option>
+                    </select>
+                  </label>
+
+                  {/* Palette Colors */}
+                  {(settings.colorMode === 'random' || settings.colorMode === 'palette') && (
+                    <div>
+                      <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Palette</span>
+                      <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+                        {settings.colorPalette.map((color, i) => (
+                          <div key={i} className="relative group">
+                            <input type="color" value={color}
+                              onChange={(e) => updatePaletteColor(i, e.target.value)} />
+                            {settings.colorPalette.length > 1 && (
+                              <button onClick={() => removePaletteColor(i)}
+                                className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white rounded-full text-[8px] font-bold leading-none hidden group-hover:flex items-center justify-center">
+                                &times;
+                              </button>
+                            )}
+                          </div>
+                        ))}
+                        <button onClick={addPaletteColor}
+                          className="w-8 h-8 rounded border-2 border-dashed border-slate-300 text-slate-400 hover:border-violet-400 hover:text-violet-500 text-lg font-bold transition-colors flex items-center justify-center">
+                          +
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Gradient Colors */}
+                  {settings.colorMode === 'gradient' && (
+                    <div className="flex gap-4">
+                      <label>
+                        <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Start</span>
+                        <input type="color" value={settings.gradientStart}
+                          onChange={(e) => updateSetting('gradientStart', e.target.value)}
+                          className="block mt-1" />
+                      </label>
+                      <label>
+                        <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">End</span>
+                        <input type="color" value={settings.gradientEnd}
+                          onChange={(e) => updateSetting('gradientEnd', e.target.value)}
+                          className="block mt-1" />
+                      </label>
+                    </div>
+                  )}
+
+                  {/* Stroke */}
+                  <div className="flex gap-4 items-end">
+                    <label className="flex-1">
+                      <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Stroke Width: {settings.strokeWidth}</span>
+                      <input type="range" min="0" max="5" step="0.5" value={settings.strokeWidth}
+                        onChange={(e) => updateSetting('strokeWidth', parseFloat(e.target.value))}
+                        className="w-full mt-1" />
+                    </label>
+                    <label>
+                      <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Color</span>
+                      <input type="color" value={settings.strokeColor}
+                        onChange={(e) => updateSetting('strokeColor', e.target.value)}
+                        className="block mt-1" />
+                    </label>
+                  </div>
+
+                  {/* Opacity */}
+                  <label className="block">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Cell Opacity: {Math.round(settings.cellOpacity * 100)}%</span>
+                    <input type="range" min="0" max="1" step="0.05" value={settings.cellOpacity}
+                      onChange={(e) => updateSetting('cellOpacity', parseFloat(e.target.value))}
+                      className="w-full mt-1" />
+                  </label>
+
+                  {/* Fill Tolerance */}
+                  <label className="block">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Fill Tolerance: {settings.fillTolerance}</span>
+                    <input type="range" min="1" max="128" value={settings.fillTolerance}
+                      onChange={(e) => updateSetting('fillTolerance', parseInt(e.target.value))}
+                      className="w-full mt-1" />
+                    <span className="text-[10px] text-slate-400">Lower = stricter boundary detection. Increase if regions bleed through thin strokes.</span>
+                  </label>
+
+                  {/* Reset */}
+                  <button onClick={() => setSettings(DEFAULT_SETTINGS)}
+                    className="text-xs text-slate-400 hover:text-red-500 font-bold transition-colors">
+                    Reset to defaults
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </main>
+
+      {/* Hidden thick-stroke canvas for flood fill */}
+      <canvas ref={thickCanvasRef} className="hidden" />
+    </div>
+  );
+};
+
+const container = document.getElementById('voronoi-shapes-root');
+const root = createRoot(container);
+root.render(<App />);

--- a/applications/voronoi-shapes/main.jsx
+++ b/applications/voronoi-shapes/main.jsx
@@ -15,20 +15,21 @@ function cn(...inputs) {
 
 // --- Constants ---
 
-const STORAGE_KEY = 'voronoi-shapes-settings';
+const STORAGE_KEY = 'voronoi-shapes-settings-v2';
 const MAX_CANVAS_SIZE = 900;
 
 const DEFAULT_SETTINGS = {
   pointCount: 100,
-  colorMode: 'random',
+  colorMode: 'outline',
   colorPalette: ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD', '#98D8C8'],
-  strokeWidth: 1,
+  strokeWidth: 0.3,   // mm
   strokeColor: '#333333',
   cellOpacity: 0.85,
   gradientStart: '#FF6B6B',
   gradientEnd: '#4ECDC4',
   fillTolerance: 30,
-  gapWidth: 4,
+  gapWidth: 1,         // mm – material left between cells
+  minCellSize: 2,      // mm – cells smaller than this are dropped
   smoothIterations: 2,
 };
 
@@ -218,6 +219,7 @@ function interpolateColor(c1, c2, t) {
 
 function generateCellColor(index, total, settings) {
   const { colorMode, colorPalette, gradientStart, gradientEnd } = settings;
+  if (colorMode === 'outline') return 'none';
   if (colorMode === 'gradient') {
     return interpolateColor(gradientStart, gradientEnd, total > 1 ? index / (total - 1) : 0);
   }
@@ -320,12 +322,18 @@ function parseSVGDimensions(svgContent) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(svgContent, 'image/svg+xml');
   const svg = doc.querySelector('svg');
+
+  // Detect physical unit from width attribute (e.g. "190.000mm")
+  const widthAttr = svg.getAttribute('width') || '';
+  const unitMatch = widthAttr.match(/(mm|cm|in|pt)$/);
+  const unit = unitMatch ? unitMatch[1] : '';
+
   const vb = svg.getAttribute('viewBox');
   if (vb) {
     const parts = vb.trim().split(/[\s,]+/).map(Number);
-    return { width: parts[2], height: parts[3] };
+    return { width: parts[2], height: parts[3], unit };
   }
-  return { width: parseFloat(svg.getAttribute('width')) || 800, height: parseFloat(svg.getAttribute('height')) || 600 };
+  return { width: parseFloat(widthAttr) || 800, height: parseFloat(svg.getAttribute('height')) || 600, unit };
 }
 
 function maskToSVGPath(mask, width, height, blockSize = 2) {
@@ -379,8 +387,20 @@ function maskToSVGPath(mask, width, height, blockSize = 2) {
   return spans.filter(Boolean).map(s => `M${s.x} ${s.y}h${s.w}v${s.h}h${-s.w}Z`).join('');
 }
 
-function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight) {
-  const erosionRadius = Math.ceil(settings.gapWidth / 2);
+function polygonArea(polygon) {
+  let area = 0;
+  const n = polygon.length - 1; // last point === first (closed)
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    area += polygon[i][0] * polygon[j][1];
+    area -= polygon[j][0] * polygon[i][1];
+  }
+  return Math.abs(area) / 2;
+}
+
+function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight, pxPerUnit) {
+  const gapPx = settings.gapWidth * pxPerUnit;
+  const erosionRadius = Math.ceil(gapPx / 2);
   const erodedMask = erodeMask(region.mask, canvasWidth, canvasHeight, erosionRadius);
   const erodedBounds = computeBounds(erodedMask, canvasWidth, canvasHeight);
   if (!erodedBounds) return { cells: [], erodedMask };
@@ -402,7 +422,10 @@ function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight) {
   const delaunay = Delaunay.from(allPoints);
   const voronoi = delaunay.voronoi([0, 0, canvasWidth, canvasHeight]);
   const cells = [];
-  const insetAmount = settings.gapWidth / 2; // half gap per side
+  const insetAmount = gapPx / 2; // half gap per side
+  // Min cell area in px² — derived from the linear mm setting
+  const minSizePx = settings.minCellSize * pxPerUnit;
+  const minAreaPx = minSizePx * minSizePx;
 
   // Only generate cells for interior points (not guards)
   for (let i = 0; i < interiorPoints.length; i++) {
@@ -413,6 +436,9 @@ function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight) {
     const inset = insetPolygon(poly, insetAmount);
     if (!inset) continue; // cell collapsed, skip
 
+    // Drop cells that are too small to cut cleanly
+    if (polygonArea(inset) < minAreaPx) continue;
+
     const smoothed = chaikinSmooth(inset, settings.smoothIterations);
     cells.push({
       polygon: smoothed,
@@ -422,7 +448,7 @@ function generateVoronoiForRegion(region, settings, canvasWidth, canvasHeight) {
   return { cells, erodedMask };
 }
 
-function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voronoiMap, settings) {
+function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voronoiMap, settings, pxPerUnit) {
   ctx.clearRect(0, 0, canvasWidth, canvasHeight);
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(0, 0, canvasWidth, canvasHeight);
@@ -464,12 +490,15 @@ function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voron
           cellCtx.lineTo(cell.polygon[j][0], cell.polygon[j][1]);
         }
         cellCtx.closePath();
-        cellCtx.fillStyle = cell.color;
-        cellCtx.fill();
-        if (settings.strokeWidth > 0) {
+        if (settings.colorMode !== 'outline') {
+          cellCtx.fillStyle = cell.color;
+          cellCtx.fill();
+        }
+        const strokePx = settings.strokeWidth * pxPerUnit;
+        if (strokePx > 0 || settings.colorMode === 'outline') {
           cellCtx.globalAlpha = 1;
           cellCtx.strokeStyle = settings.strokeColor;
-          cellCtx.lineWidth = settings.strokeWidth;
+          cellCtx.lineWidth = settings.colorMode === 'outline' ? Math.max(strokePx, 0.5) : strokePx;
           cellCtx.stroke();
           cellCtx.globalAlpha = settings.cellOpacity;
         }
@@ -507,7 +536,179 @@ function renderToCanvas(ctx, canvasWidth, canvasHeight, svgImage, regions, voron
   ctx.globalCompositeOperation = 'source-over';
 }
 
+// --- SVG path transform helpers ---
+// Bake affine transforms directly into path coordinates so the output
+// has no `transform` attributes (LightBurn ignores them).
+
+function parseTransformAttr(s) {
+  // Returns affine matrix [a, b, c, d, e, f] from a transform string.
+  // SVG matrix(a,b,c,d,e,f): x' = a*x + c*y + e,  y' = b*x + d*y + f
+  if (!s) return [1, 0, 0, 1, 0, 0];
+  const m = s.match(/matrix\(\s*([-\d.e+]+)[\s,]+([-\d.e+]+)[\s,]+([-\d.e+]+)[\s,]+([-\d.e+]+)[\s,]+([-\d.e+]+)[\s,]+([-\d.e+]+)\s*\)/);
+  if (m) return m.slice(1).map(Number);
+  const t = s.match(/translate\(\s*([-\d.e+]+)[\s,]*([-\d.e+]*)\s*\)/);
+  if (t) return [1, 0, 0, 1, Number(t[1]), Number(t[2] || 0)];
+  return [1, 0, 0, 1, 0, 0];
+}
+
+function composeMat(m1, m2) {
+  // m2 applied first, then m1.  [a c e][a c e]
+  const [a1, b1, c1, d1, e1, f1] = m1;
+  const [a2, b2, c2, d2, e2, f2] = m2;
+  return [
+    a1 * a2 + c1 * b2, b1 * a2 + d1 * b2,
+    a1 * c2 + c1 * d2, b1 * c2 + d1 * d2,
+    a1 * e2 + c1 * f2 + e1, b1 * e2 + d1 * f2 + f1,
+  ];
+}
+
+function transformPathD(d, mat) {
+  const [a, b, c, dd, e, f] = mat;
+  const tx = (x, y) => [a * x + c * y + e, b * x + dd * y + f];
+  const fmt = (v) => +v.toFixed(4);
+
+  const tokens = d.match(/[MmLlHhVvCcSsQqTtAaZz]|[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?/g);
+  if (!tokens) return d;
+
+  let out = '';
+  let i = 0;
+  let cx = 0, cy = 0; // current untransformed position
+
+  while (i < tokens.length) {
+    const cmd = tokens[i++];
+    const abs = cmd === cmd.toUpperCase();
+    const type = cmd.toUpperCase();
+    if (type === 'Z') { out += 'Z'; continue; }
+
+    const sizes = { M: 2, L: 2, T: 2, H: 1, V: 1, C: 6, S: 4, Q: 4, A: 7 };
+    const sz = sizes[type] || 0;
+    const vals = [];
+    while (i < tokens.length && !/[A-Za-z]/.test(tokens[i])) vals.push(parseFloat(tokens[i++]));
+
+    for (let j = 0; j < vals.length; j += sz) {
+      if (type === 'M' || type === 'L' || type === 'T') {
+        let x = vals[j], y = vals[j + 1];
+        if (!abs) { x += cx; y += cy; }
+        cx = x; cy = y;
+        const [nx, ny] = tx(x, y);
+        out += `${type}${fmt(nx)},${fmt(ny)}`;
+      } else if (type === 'H') {
+        let x = vals[j];
+        if (!abs) x += cx;
+        cx = x;
+        const [nx, ny] = tx(x, cy);
+        out += `L${fmt(nx)},${fmt(ny)}`;
+      } else if (type === 'V') {
+        let y = vals[j];
+        if (!abs) y += cy;
+        cy = y;
+        const [nx, ny] = tx(cx, y);
+        out += `L${fmt(nx)},${fmt(ny)}`;
+      } else if (type === 'C') {
+        let [x1, y1, x2, y2, x, y] = vals.slice(j, j + 6);
+        if (!abs) { x1 += cx; y1 += cy; x2 += cx; y2 += cy; x += cx; y += cy; }
+        cx = x; cy = y;
+        const [nx1, ny1] = tx(x1, y1);
+        const [nx2, ny2] = tx(x2, y2);
+        const [nx, ny] = tx(x, y);
+        out += `C${fmt(nx1)},${fmt(ny1)} ${fmt(nx2)},${fmt(ny2)} ${fmt(nx)},${fmt(ny)}`;
+      } else if (type === 'S') {
+        let [x2, y2, x, y] = vals.slice(j, j + 4);
+        if (!abs) { x2 += cx; y2 += cy; x += cx; y += cy; }
+        cx = x; cy = y;
+        const [nx2, ny2] = tx(x2, y2);
+        const [nx, ny] = tx(x, y);
+        out += `S${fmt(nx2)},${fmt(ny2)} ${fmt(nx)},${fmt(ny)}`;
+      } else if (type === 'Q') {
+        let [x1, y1, x, y] = vals.slice(j, j + 4);
+        if (!abs) { x1 += cx; y1 += cy; x += cx; y += cy; }
+        cx = x; cy = y;
+        const [nx1, ny1] = tx(x1, y1);
+        const [nx, ny] = tx(x, y);
+        out += `Q${fmt(nx1)},${fmt(ny1)} ${fmt(nx)},${fmt(ny)}`;
+      } else if (type === 'A') {
+        let [rx, ry, xRot, la, sw, x, y] = vals.slice(j, j + 7);
+        if (!abs) { x += cx; y += cy; }
+        cx = x; cy = y;
+        const det = a * dd - b * c;
+        if (det < 0) sw = sw ? 0 : 1; // flip sweep on mirror
+        const [nx, ny] = tx(x, y);
+        out += `A${fmt(rx)},${fmt(ry)} ${xRot} ${la} ${sw} ${fmt(nx)},${fmt(ny)}`;
+      }
+    }
+  }
+  return out;
+}
+
+function flattenOriginalPaths(svgContent) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgContent, 'image/svg+xml');
+  const svg = doc.querySelector('svg');
+
+  // ViewBox offset — shift origin to (0,0)
+  const vb = svg.getAttribute('viewBox');
+  const [vbX, vbY] = vb ? vb.trim().split(/[\s,]+/).map(Number) : [0, 0];
+  const vbMat = [1, 0, 0, 1, -vbX, -vbY];
+
+  const paths = svg.querySelectorAll('path');
+  const lines = [];
+  for (const el of paths) {
+    const elMat = parseTransformAttr(el.getAttribute('transform'));
+    const mat = composeMat(vbMat, elMat); // element transform first, then viewBox shift
+
+    const d = el.getAttribute('d');
+    if (!d) continue;
+    const newD = transformPathD(d, mat);
+
+    // Extract stroke props from CSS style attribute
+    let stroke = '#000000', strokeWidth = '0.05';
+    const style = el.getAttribute('style') || '';
+    const sm = style.match(/stroke\s*:\s*([^;]+)/);
+    if (sm) stroke = sm[1].trim();
+    const swm = style.match(/stroke-width\s*:\s*([^;]+)/);
+    if (swm) strokeWidth = parseFloat(swm[1]).toString();
+
+    lines.push(`  <path d="${newD}" fill="none" stroke="${stroke}" stroke-width="${strokeWidth}"/>`);
+  }
+  return lines;
+}
+
 function exportAsSVG(svgContent, canvasWidth, canvasHeight, regions, voronoiMap, settings, svgDims) {
+  const isOutline = settings.colorMode === 'outline';
+  const unit = svgDims.unit || '';
+  // Scale factor: canvas pixels → physical SVG units (e.g. mm)
+  const pxToPhys = svgDims.width / canvasWidth;
+
+  // In outline mode: flat list of polygons in physical units (mm), no clip
+  // paths, no nested SVG. Original frame paths included. LightBurn-compatible.
+  if (isOutline) {
+    const physW = svgDims.width;
+    const physH = svgDims.height;
+    const parts = [];
+
+    // Include original SVG paths (frame outlines) flattened for LightBurn
+    const origPaths = flattenOriginalPaths(svgContent);
+    parts.push(...origPaths);
+
+    // Voronoi cell outlines
+    for (const region of regions) {
+      const data = voronoiMap.get(region.id);
+      const cells = data?.cells;
+      if (!cells || cells.length === 0) continue;
+      for (const cell of cells) {
+        const pts = cell.polygon.map(p =>
+          `${(p[0] * pxToPhys).toFixed(3)},${(p[1] * pxToPhys).toFixed(3)}`
+        ).join(' ');
+        const sw = Math.max(settings.strokeWidth, 0.1);
+        parts.push(`  <polygon points="${pts}" fill="none" stroke="${settings.strokeColor}" stroke-width="${sw}"/>`);
+      }
+    }
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${physW}${unit}" height="${physH}${unit}" viewBox="0 0 ${physW} ${physH}">
+${parts.join('\n')}
+</svg>`;
+  }
+
   const regionDefs = [];
   const regionGroups = [];
 
@@ -521,9 +722,10 @@ function exportAsSVG(svgContent, canvasWidth, canvasHeight, regions, voronoiMap,
     const pathD = maskToSVGPath(clipMask, canvasWidth, canvasHeight);
     regionDefs.push(`<clipPath id="${clipId}"><path d="${pathD}"/></clipPath>`);
 
+    const strokePx = settings.strokeWidth / pxToPhys; // convert mm back to canvas pixels
     const polys = cells.map(cell => {
       const pts = cell.polygon.map(p => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
-      return `<polygon points="${pts}" fill="${cell.color}" fill-opacity="${settings.cellOpacity}" stroke="${settings.strokeColor}" stroke-width="${settings.strokeWidth}"/>`;
+      return `<polygon points="${pts}" fill="${cell.color}" fill-opacity="${settings.cellOpacity}" stroke="${settings.strokeColor}" stroke-width="${strokePx.toFixed(1)}"/>`;
     }).join('\n      ');
 
     regionGroups.push(`<g clip-path="url(#${clipId})">\n      ${polys}\n    </g>`);
@@ -565,6 +767,10 @@ const App = () => {
   });
   const [settingsOpen, setSettingsOpen] = useState(true);
   const [regenKey, setRegenKey] = useState(0);
+
+  // Pixels per physical unit (e.g. mm). When no SVG loaded, default 1:1.
+  const pxPerUnit = svgDims ? canvasSize.width / svgDims.width : 1;
+  const displayUnit = svgDims?.unit || 'px';
 
   const canvasRef = useRef(null);
   const thickCanvasRef = useRef(null);
@@ -626,11 +832,11 @@ const App = () => {
     }
     const map = new Map();
     for (const region of regions) {
-      const data = generateVoronoiForRegion(region, settings, canvasSize.width, canvasSize.height);
+      const data = generateVoronoiForRegion(region, settings, canvasSize.width, canvasSize.height, pxPerUnit);
       map.set(region.id, data);
     }
     setVoronoiMap(map);
-  }, [regions, settings, canvasSize, regenKey]);
+  }, [regions, settings, canvasSize, regenKey, pxPerUnit]);
 
   // Render canvas
   useEffect(() => {
@@ -639,8 +845,8 @@ const App = () => {
     cvs.width = canvasSize.width;
     cvs.height = canvasSize.height;
     const ctx = cvs.getContext('2d');
-    renderToCanvas(ctx, canvasSize.width, canvasSize.height, svgImage, regions, voronoiMap, settings);
-  }, [svgImage, regions, voronoiMap, settings, canvasSize]);
+    renderToCanvas(ctx, canvasSize.width, canvasSize.height, svgImage, regions, voronoiMap, settings, pxPerUnit);
+  }, [svgImage, regions, voronoiMap, settings, canvasSize, pxPerUnit]);
 
   const handleFileUpload = (e) => {
     const file = e.target.files?.[0];
@@ -795,6 +1001,7 @@ const App = () => {
                 <span className="text-xs font-bold text-slate-500 flex items-center gap-2">
                   <MousePointer2 size={14} />
                   Click regions to select/deselect
+                  {svgDims && <span className="text-slate-400 font-normal ml-1">({svgDims.width} × {svgDims.height} {displayUnit})</span>}
                 </span>
                 <div className="flex gap-2">
                   <button
@@ -868,7 +1075,7 @@ const App = () => {
               >
                 <span className="flex items-center gap-2 text-sm font-bold text-slate-700">
                   <Settings2 size={16} />
-                  Settings
+                  Laser Cut Settings
                 </span>
                 {settingsOpen ? <ChevronUp size={16} className="text-slate-400" /> : <ChevronDown size={16} className="text-slate-400" />}
               </button>
@@ -883,13 +1090,22 @@ const App = () => {
                       className="w-full mt-1" />
                   </label>
 
-                  {/* Gap Width (web thickness for laser cutting) */}
+                  {/* Web Width (material between cuts) */}
                   <label className="block">
-                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Gap Width: {settings.gapWidth}px</span>
-                    <input type="range" min="0" max="20" step="0.5" value={settings.gapWidth}
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Web Width: {settings.gapWidth} {displayUnit}</span>
+                    <input type="range" min="0" max="10" step="0.1" value={settings.gapWidth}
                       onChange={(e) => updateSetting('gapWidth', parseFloat(e.target.value))}
                       className="w-full mt-1" />
-                    <span className="text-[10px] text-slate-400">Width of the web between cells. Each cell is a separate island for laser cutting.</span>
+                    <span className="text-[10px] text-slate-400">Material left between cells. Must be thick enough for structural strength.</span>
+                  </label>
+
+                  {/* Min Cell Size */}
+                  <label className="block">
+                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Min Cell Size: {settings.minCellSize} {displayUnit}</span>
+                    <input type="range" min="0" max="20" step="0.5" value={settings.minCellSize}
+                      onChange={(e) => updateSetting('minCellSize', parseFloat(e.target.value))}
+                      className="w-full mt-1" />
+                    <span className="text-[10px] text-slate-400">Cells smaller than this are dropped. Prevents tiny pieces that weaken the cut.</span>
                   </label>
 
                   {/* Smoothing */}
@@ -907,6 +1123,7 @@ const App = () => {
                     <select value={settings.colorMode}
                       onChange={(e) => updateSetting('colorMode', e.target.value)}
                       className="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm font-medium">
+                      <option value="outline">Outline only (laser cut)</option>
                       <option value="random">Random from palette</option>
                       <option value="palette">Sequential from palette</option>
                       <option value="gradient">Gradient</option>
@@ -914,7 +1131,7 @@ const App = () => {
                   </label>
 
                   {/* Palette Colors */}
-                  {(settings.colorMode === 'random' || settings.colorMode === 'palette') && (
+                  {(settings.colorMode === 'random' || settings.colorMode === 'palette') && settings.colorMode !== 'outline' && (
                     <div>
                       <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Palette</span>
                       <div className="flex items-center gap-1.5 mt-1 flex-wrap">
@@ -959,8 +1176,8 @@ const App = () => {
                   {/* Stroke */}
                   <div className="flex gap-4 items-end">
                     <label className="flex-1">
-                      <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Stroke Width: {settings.strokeWidth}</span>
-                      <input type="range" min="0" max="5" step="0.5" value={settings.strokeWidth}
+                      <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Stroke Width: {settings.strokeWidth} {displayUnit}</span>
+                      <input type="range" min="0" max="2" step="0.05" value={settings.strokeWidth}
                         onChange={(e) => updateSetting('strokeWidth', parseFloat(e.target.value))}
                         className="w-full mt-1" />
                     </label>
@@ -973,12 +1190,14 @@ const App = () => {
                   </div>
 
                   {/* Opacity */}
+                  {settings.colorMode !== 'outline' && (
                   <label className="block">
                     <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">Cell Opacity: {Math.round(settings.cellOpacity * 100)}%</span>
                     <input type="range" min="0" max="1" step="0.05" value={settings.cellOpacity}
                       onChange={(e) => updateSetting('cellOpacity', parseFloat(e.target.value))}
                       className="w-full mt-1" />
                   </label>
+                  )}
 
                   {/* Fill Tolerance */}
                   <label className="block">

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,14 @@ cd /code
 # Build Node assets if package.json exists
 if [ -f package.json ]; then
   npm install
+
+  # Docker volume mounts may create copies in .bin instead of symlinks,
+  # breaking relative imports. Recreate vite as a proper symlink.
+  if [ -f node_modules/.bin/vite ] && [ ! -L node_modules/.bin/vite ]; then
+    rm node_modules/.bin/vite
+    ln -s ../vite/bin/vite.js node_modules/.bin/vite
+  fi
+
   npm run build
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "kylejameswalker.github.io",
       "dependencies": {
         "clsx": "^2.1.1",
+        "d3-delaunay": "^6.0.4",
         "lucide-react": "^0.460.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3231,6 +3232,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3347,6 +3360,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/didyoumean": {
@@ -5545,6 +5567,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.59.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,14 +38,13 @@
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
-      "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
+      "integrity": "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema": "^0.4.0",
-        "jsonpointer": "^5.0.0",
+        "jsonpointer": "^5.0.1",
         "leven": "^3.1.0"
       },
       "engines": {
@@ -199,9 +198,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.7.tgz",
-      "integrity": "sha512-6Fqi8MtQ/PweQ9xvux65emkLQ83uB+qAVtfHkC9UodyHMIZdxNI01HjLCLUtybElp2KY2XNE0nOgyP1E1vXw9w==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -390,23 +389,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1454,9 +1453,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-      "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1554,9 +1553,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2240,10 +2239,23 @@
         }
       }
     },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -2255,9 +2267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -2269,9 +2281,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -2283,9 +2295,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -2297,9 +2309,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -2311,9 +2323,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -2325,13 +2337,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,13 +2354,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,13 +2371,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,13 +2388,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,13 +2405,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,13 +2422,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,13 +2439,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,13 +2456,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2437,13 +2473,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,13 +2490,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,13 +2507,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,13 +2524,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,13 +2541,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,9 +2558,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -2521,9 +2572,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -2535,9 +2586,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -2549,9 +2600,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -2563,9 +2614,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -2577,9 +2628,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -2741,19 +2792,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -2828,9 +2866,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.24",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
-      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
       "dev": true,
       "funding": [
         {
@@ -2849,7 +2887,7 @@
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001766",
+        "caniuse-lite": "^1.0.30001774",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -2881,14 +2919,14 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.16.tgz",
-      "integrity": "sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -2896,13 +2934,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.1.tgz",
-      "integrity": "sha512-ENp89vM9Pw4kv/koBb5N2f9bDZsR0hpf3BdPMOg/pkS3pwO4dzNnQZVXtBbeyAadgm865DmQG2jMMLqmZXvuCw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "core-js-compat": "^3.48.0"
       },
       "peerDependencies": {
@@ -2910,13 +2948,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.7.tgz",
-      "integrity": "sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.7"
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2933,9 +2971,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2959,9 +2997,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2985,9 +3023,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3005,11 +3043,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3026,15 +3064,15 @@
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3086,9 +3124,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {
@@ -3181,9 +3219,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3417,16 +3455,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3699,24 +3737,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -3735,9 +3755,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4683,13 +4703,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4764,9 +4777,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4859,27 +4872,14 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4937,9 +4937,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5077,9 +5077,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5094,13 +5094,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5137,9 +5137,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -5411,19 +5411,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5514,9 +5501,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5537,12 +5524,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -5575,9 +5563,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5591,31 +5579,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -5841,14 +5829,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6212,9 +6200,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6267,20 +6255,51 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -6540,9 +6559,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6643,6 +6662,37 @@
         "@vite-pwa/assets-generator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6908,19 +6958,6 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/workbox-build/node_modules/pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "d3-delaunay": "^6.0.4",
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pages/applications/index.md
+++ b/pages/applications/index.md
@@ -10,6 +10,7 @@ teaser: "Web applications and tools."
     <ul class="side-nav">
       <li><a href="{{ site.baseurl }}/applications/cardboard-slicer/">Cardboard Slicer</a> — Slice 3D STL models for laser-cut cardboard assembly.</li>
       <li><a href="{{ site.baseurl }}/applications/lead-scanner/">Lead Scanner</a> — Mobile lead collection for conference exhibitors.</li>
+      <li><a href="{{ site.baseurl }}/applications/voronoi-shapes/">Voronoi Shapes</a> — Generate Voronoi patterns within SVG regions.</li>
     </ul>
   </div>
 </div>

--- a/pages/applications/voronoi-shapes.md
+++ b/pages/applications/voronoi-shapes.md
@@ -1,0 +1,8 @@
+---
+layout: app
+title: "Voronoi Shapes"
+permalink: "/applications/voronoi-shapes/"
+teaser: "Generate Voronoi patterns within SVG regions using flood fill selection."
+---
+
+<div id="voronoi-shapes-root"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
       input: {
         'cardboard-slicer': 'applications/cardboard-slicer/main.jsx',
         'lead-scanner': 'applications/lead-scanner/main.jsx',
+        'voronoi-shapes': 'applications/voronoi-shapes/main.jsx',
       },
       output: {
         entryFileNames: '[name].js',


### PR DESCRIPTION
## Summary

Adds a Voronoi pattern generator focused on laser cutting workflows.

- Upload SVG, select regions via flood fill, generate organic Voronoi cell patterns
- Cells are separate "islands" with uniform gaps (web width) for laser cutting
- Chaikin corner-cutting smoothing for organic curves, boundary guard points for natural edges
- All dimensions in mm parsed from SVG physical units
- Outline-only color mode with LightBurn-compatible SVG export (no clip paths, no transforms, coordinates in mm)
- Min cell size filter to drop pieces too small to cut cleanly
- Docker build pipeline fix for vite symlink in volume mounts

## Test plan

- [ ] Upload an SVG with mm dimensions, verify dimensions display correctly
- [ ] Generate Voronoi pattern, adjust web width / min cell size / smoothing
- [ ] Export SVG in outline mode, open in LightBurn — frame lines and cells should align
- [ ] Verify non-outline color modes (random, palette, gradient) still work
- [ ] Docker: `make build && make run` succeeds

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
