### PR TITLE
fix(ci): update Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install and build Node assets
         run: |
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -48,7 +48,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Switched GitHub Pages source from "Deploy from a branch" to "GitHub Actions" via API — this disables the redundant built-in `pages-build-deployment` workflow that was failing because it uses Ruby Sass 3.7.4 (incompatible with `@use` syntax)
- Bumped all GitHub Actions to latest major versions (`checkout@v6`, `setup-node@v6`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`)
- Updated Node.js from 20 to 22 to resolve the deprecation warnings before the June 2026 deadline

## Context

After merging #7, the built-in `pages-build-deployment` was failing on the Dart Sass `@use` syntax. The custom `Deploy to GitHub Pages` workflow was already succeeding — it uses Jekyll 4.4 with `sass-embedded`. The built-in builder was redundant.

## Test plan

- [x] Verified Pages source is now `workflow` via `gh api`
- [x] Re-triggered deploy workflow — build and deploy both passed

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
