### PR TITLE
fix(ci): pin upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5.0.0
 
   deploy:
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v4
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary

- Pin `actions/upload-pages-artifact` back to `@v4` — the `v5.0.0` release exists but the `v5` major version tag hasn't been created yet, so `@v5` fails to resolve

## Context

Follow-up to #8. The `deploy-pages@v5` and other actions resolved fine, but `upload-pages-artifact` is behind on tagging.

## Test plan

- [ ] Workflow resolves all actions and deploys successfully

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
